### PR TITLE
rely on plugin version instead of terminal type for notifications

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ export const WarpPlugin: Plugin = async ({ client, directory }) => {
         service: "opencode-warp",
         level: "warn",
         message:
-          "⚠️ Please update Warp to get agent notifications — your terminal does not declare cli-agent protocol support",
+          "⚠️ Detected unsupported Warp version. Please update Warp to use this pluginDetected unsupported Warp version. Please update Warp to use this plugin",
       },
     })
     return {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,18 @@ function sendPermissionNotification(perm: Permission, cwd: string): void {
 }
 
 export const WarpPlugin: Plugin = async ({ client, directory }) => {
+  if (!process.env.WARP_CLI_AGENT_PROTOCOL_VERSION) {
+    await client.app.log({
+      body: {
+        service: "opencode-warp",
+        level: "warn",
+        message:
+          "⚠️ Please update Warp to get agent notifications — your terminal does not declare cli-agent protocol support",
+      },
+    })
+    return {}
+  }
+
   await client.app.log({
     body: {
       service: "opencode-warp",

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -2,10 +2,11 @@ import { writeFileSync } from "fs"
 
 /**
  * Send a Warp notification via OSC 777 escape sequence.
- * Only emits when running inside Warp terminal to avoid garbled output in other terminals.
+ * Only emits when Warp declares cli-agent protocol support,
+ * avoiding garbled output in other terminals (and working over SSH).
  */
 function warpNotify(title: string, body: string): void {
-  if (process.env.TERM_PROGRAM !== "WarpTerminal") return
+  if (!process.env.WARP_CLI_AGENT_PROTOCOL_VERSION) return
 
   try {
     // OSC 777 format: \033]777;notify;<title>;<body>\007

--- a/tests/notify.test.ts
+++ b/tests/notify.test.ts
@@ -11,31 +11,25 @@ mock.module("fs", () => ({
 const { warpNotify } = await import("../src/notify")
 
 describe("warpNotify", () => {
-  const originalTermProgram = process.env.TERM_PROGRAM
+  const originalVersion = process.env.WARP_CLI_AGENT_PROTOCOL_VERSION
 
   afterEach(() => {
     writeSpy.mockClear()
-    if (originalTermProgram === undefined) {
-      delete process.env.TERM_PROGRAM
+    if (originalVersion === undefined) {
+      delete process.env.WARP_CLI_AGENT_PROTOCOL_VERSION
     } else {
-      process.env.TERM_PROGRAM = originalTermProgram
+      process.env.WARP_CLI_AGENT_PROTOCOL_VERSION = originalVersion
     }
   })
 
-  it("skips when TERM_PROGRAM is not set", () => {
-    delete process.env.TERM_PROGRAM
+  it("skips when WARP_CLI_AGENT_PROTOCOL_VERSION is not set", () => {
+    delete process.env.WARP_CLI_AGENT_PROTOCOL_VERSION
     warpNotify("title", "body")
     expect(writeSpy).not.toHaveBeenCalled()
   })
 
-  it("skips for other terminal programs", () => {
-    process.env.TERM_PROGRAM = "iTerm.app"
-    warpNotify("title", "body")
-    expect(writeSpy).not.toHaveBeenCalled()
-  })
-
-  it("writes OSC 777 sequence when inside Warp", () => {
-    process.env.TERM_PROGRAM = "WarpTerminal"
+  it("writes OSC 777 sequence when Warp declares protocol support", () => {
+    process.env.WARP_CLI_AGENT_PROTOCOL_VERSION = "1"
     warpNotify("warp://cli-agent", '{"event":"stop"}')
     expect(writeSpy).toHaveBeenCalledTimes(1)
 


### PR DESCRIPTION
We shouldn't rely on the terminal being warp/gate access on this being the case, because if you're ssh-ing into another terminal using warp the plugin won't work as is.

Instead, we should rely on the declared version of the plugin that's supported. [This PR](https://github.com/warpdotdev/warp-internal/pull/23569) changes it so that we declare support in the client over ssh, so with this change the plugin works over ssh

Demo of ssh working with notifications: https://www.loom.com/share/ff3749cb62fd4a80887775ef771f8036