### PR TITLE
add hook for ask question tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@warp-dot-dev/opencode-warp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Warp terminal integration for OpenCode — native notifications and more",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export const WarpPlugin: Plugin = async ({ client, directory }) => {
         service: "opencode-warp",
         level: "warn",
         message:
-          "⚠️ Detected unsupported Warp version. Please update Warp to use this pluginDetected unsupported Warp version. Please update Warp to use this plugin",
+          "⚠️ Detected unsupported Warp version. Please update Warp to use this plugin.",
       },
     })
     return {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,9 @@ import type { Event, Part, Permission } from "@opencode-ai/sdk"
 
 import { buildPayload } from "./payload"
 import { warpNotify } from "./notify"
+import pkg from "../package.json" with { type: "json" }
 
-const PLUGIN_VERSION = "0.1.0"
+const PLUGIN_VERSION = pkg.version
 const NOTIFICATION_TITLE = "warp://cli-agent"
 
 export function truncate(str: string, maxLen: number): string {
@@ -166,6 +167,18 @@ export const WarpPlugin: Plugin = async ({ client, directory }) => {
 
       const body = buildPayload("prompt_submit", input.sessionID, cwd, {
         query: truncate(queryText, 200),
+      })
+      warpNotify(NOTIFICATION_TITLE, body)
+    },
+
+    // Fires before a tool executes — used to detect the built-in
+    // "question" tool so Warp can notify the user that input is needed.
+    "tool.execute.before": async (input) => {
+      if (input.tool !== "question") return
+
+      const cwd = directory || ""
+      const body = buildPayload("question_asked", input.sessionID, cwd, {
+        tool_name: input.tool,
       })
       warpNotify(NOTIFICATION_TITLE, body)
     },

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test"
 import assert from "node:assert/strict"
 import { truncate, extractTextFromParts } from "../src/index"
+import { buildPayload } from "../src/payload"
 
 describe("truncate", () => {
   it("returns string unchanged when under maxLen", () => {
@@ -59,5 +60,27 @@ describe("extractTextFromParts", () => {
       { type: "tool_use" as const, id: "1", name: "bash", input: {} },
     ] as any[]
     assert.strictEqual(extractTextFromParts(parts), "")
+  })
+})
+
+describe("PLUGIN_VERSION", () => {
+  it("resolves to a valid semver string from package.json", async () => {
+    const pkg = await import("../package.json", { with: { type: "json" } })
+    const version = pkg.default.version
+    assert.ok(typeof version === "string", "version should be a string")
+    assert.match(version, /^\d+\.\d+\.\d+/, "version should be semver")
+  })
+})
+
+describe("question_asked event", () => {
+  it("builds a valid question_asked payload", () => {
+    const payload = JSON.parse(
+      buildPayload("question_asked", "s1", "/tmp/proj", {
+        tool_name: "question",
+      }),
+    )
+    assert.strictEqual(payload.event, "question_asked")
+    assert.strictEqual(payload.tool_name, "question")
+    assert.strictEqual(payload.session_id, "s1")
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "bundler",
     "esModuleInterop": true,
     "strict": true,
+    "resolveJsonModule": true,
     "outDir": "dist",
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
The ask question tool is blocking (requires a user response), so we should add a hook for it so that the warp client can surface a notification and mark the session as blocked.

addresses https://github.com/warpdotdev/opencode-warp/issues/8