### PR TITLE
fix plugin publishing bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-warp",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-warp",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "license": "MIT",
       "devDependencies": {
         "@opencode-ai/plugin": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@warp-dot-dev/opencode-warp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Warp terminal integration for OpenCode — native notifications and more",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -8,11 +8,11 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "rm -rf dist && tsc",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
     "dev": "echo 'Add to your opencode.json: \"plugin\": [\"file://'$(pwd)'/src/index.ts\"]' && echo 'Then run: opencode'",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "opencode",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,18 @@
 import type { Plugin } from "@opencode-ai/plugin"
 import type { Event, Part, Permission } from "@opencode-ai/sdk"
+import { readFileSync } from "node:fs"
 
 import { buildPayload } from "./payload"
 import { warpNotify } from "./notify"
-import pkg from "../package.json" with { type: "json" }
 
-const PLUGIN_VERSION = pkg.version
+// Read the version at runtime instead of `import pkg from "../package.json"`.
+// An import would pull package.json into tsc's compilation roots and shift
+// output paths (e.g. dist/src/index.js instead of dist/index.js).
+const pkg = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+) as { version: string }
+export const PLUGIN_VERSION = pkg.version
+    
 const NOTIFICATION_TITLE = "warp://cli-agent"
 
 export function truncate(str: string, maxLen: number): string {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test"
 import assert from "node:assert/strict"
-import { truncate, extractTextFromParts } from "../src/index"
+import { truncate, extractTextFromParts, PLUGIN_VERSION } from "../src/index"
 import { buildPayload } from "../src/payload"
 
 describe("truncate", () => {
@@ -64,11 +64,12 @@ describe("extractTextFromParts", () => {
 })
 
 describe("PLUGIN_VERSION", () => {
-  it("resolves to a valid semver string from package.json", async () => {
-    const pkg = await import("../package.json", { with: { type: "json" } })
-    const version = pkg.default.version
-    assert.ok(typeof version === "string", "version should be a string")
-    assert.match(version, /^\d+\.\d+\.\d+/, "version should be semver")
+  it("resolves to a valid semver string from package.json", () => {
+    assert.ok(
+      typeof PLUGIN_VERSION === "string",
+      "PLUGIN_VERSION should be a string",
+    )
+    assert.match(PLUGIN_VERSION, /^\d+\.\d+\.\d+/, "version should be semver")
   })
 })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "esModuleInterop": true,
     "strict": true,
     "resolveJsonModule": true,
+    "rootDir": "src",
     "outDir": "dist",
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
by pulling in the pkg directly, I changed where the compilation output path went, which messed up opencode importing (luckily the original version also stuck around, and no one should have been prompted to update anyways because we haven't updated the client, so should be no harm done). This fixes the issue