### PR TITLE
fix bad exported fn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-warp",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-warp",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "devDependencies": {
         "@opencode-ai/plugin": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@warp-dot-dev/opencode-warp",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Warp terminal integration for OpenCode — native notifications and more",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,14 @@
 import type { Plugin } from "@opencode-ai/plugin"
 import type { Event, Part, Permission } from "@opencode-ai/sdk"
-import { readFileSync } from "node:fs"
 
 import { buildPayload } from "./payload"
 import { warpNotify } from "./notify"
 
-// Read the version at runtime instead of `import pkg from "../package.json"`.
-// An import would pull package.json into tsc's compilation roots and shift
-// output paths (e.g. dist/src/index.js instead of dist/index.js).
-const pkg = JSON.parse(
-  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
-) as { version: string }
-export const PLUGIN_VERSION = pkg.version
-    
+// Must be kept in sync with the "version" field in package.json.
+// NOTE: do not `export` this constant — opencode's legacy plugin loader
+// treats every named export as a plugin function and throws if any export
+// is not a function ("Plugin export is not a function").
+const PLUGIN_VERSION = "0.1.4"
 const NOTIFICATION_TITLE = "warp://cli-agent"
 
 export function truncate(str: string, maxLen: number): string {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test"
 import assert from "node:assert/strict"
-import { truncate, extractTextFromParts, PLUGIN_VERSION } from "../src/index"
+import { truncate, extractTextFromParts } from "../src/index"
 import { buildPayload } from "../src/payload"
 
 describe("truncate", () => {
@@ -60,16 +60,6 @@ describe("extractTextFromParts", () => {
       { type: "tool_use" as const, id: "1", name: "bash", input: {} },
     ] as any[]
     assert.strictEqual(extractTextFromParts(parts), "")
-  })
-})
-
-describe("PLUGIN_VERSION", () => {
-  it("resolves to a valid semver string from package.json", () => {
-    assert.ok(
-      typeof PLUGIN_VERSION === "string",
-      "PLUGIN_VERSION should be a string",
-    )
-    assert.match(PLUGIN_VERSION, /^\d+\.\d+\.\d+/, "version should be semver")
   })
 })
 


### PR DESCRIPTION
Opencode treats all exported functions as plugin builders when pulling in from npm, so exporting the plugin version borked things