### PR TITLE
bump plugin version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@warp-dot-dev/opencode-warp",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@warp-dot-dev/opencode-warp",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "undici-types": "^7.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@warp-dot-dev/opencode-warp",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Warp terminal integration for OpenCode — native notifications and more",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { truncate, extractTextFromParts } from "./utils"
 // NOTE: do not `export` this constant — opencode's legacy plugin loader
 // treats every named export as a plugin function and throws if any export
 // is not a function ("Plugin export is not a function").
-const PLUGIN_VERSION = "0.1.5"
+const PLUGIN_VERSION = "0.1.6"
 const NOTIFICATION_TITLE = "warp://cli-agent"
 
 function sendPermissionNotification(perm: Permission, cwd: string): void {


### PR DESCRIPTION
I forgot to update the plugin version before merging [this PR](https://github.com/warpdotdev/opencode-warp/pull/12), but we need to update the version to release a new plugin version